### PR TITLE
Check wether connection exists

### DIFF
--- a/src/server/transport/websocket-transport.coffee
+++ b/src/server/transport/websocket-transport.coffee
@@ -49,8 +49,9 @@ class WebSocketTransport extends EventEmitter
 
 	# Senders
 	send: (session_id, message) =>
-		connection = @connections.get session_id
-		connection.sendUTF JSON.stringify(message)
+		if @connections.has session_id
+			connection = @connections.get session_id
+			connection.sendUTF JSON.stringify(message)
 
 	broadcast: (sender_session, id, value) ->
 		@sessions.forEach (session) =>


### PR DESCRIPTION
Potentially method `send` could be called on already closed (terminated) connection because of sync code origin. It means that `close` handler on `server` has already been called and connection no longer exists in `@connections` Map. That causes `sendUTF of undefined` error.
